### PR TITLE
Avoid creation of extra local directory.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -77,7 +77,7 @@ var compiler = {
     require.extensions['.tsx'] = empty
     tmpDir = options['cache-directory']
       ? path.resolve(options['cache-directory'])
-      : path.join(os.tmpdir(), fs.mkdtempSync('.ts-node'))
+      : fs.mkdtempSync(path.join(os.tmpdir(), '.ts-node'))
     var compilerOptions
     if (options['compilerOptions']) {
       try {


### PR DESCRIPTION
A previous PR (#22) updated the way the temp directory was created to avoid collisions between multiple processes. This was a great addition, but it also created empty local directories that needed to be manually cleaned up.

The fs.mkdtempSync() function *creates* a directory and returns it's path. The PR was first creating the temp directory locally, then using the resulting local temp directory path to construct the fully-qualified temp directory path.

This fix instead uses the fully-qualified temp directory path prefix to create the temp dir and returns the resulting fully-qualified temp directory path.