### PR TITLE
ts-node expects ignore to be an array

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -127,6 +127,11 @@ var compiler = {
       }
     }
 
+    let ignore = options['ignore'] || process.env['TS_NODE_IGNORE'];
+    if (ignore && typeof ignore === 'string') {
+      ignore = [ignore];
+    }
+
     var tsNodeOptions = {
       fast: options['fast'],
       cache: options['cache'] || !options['no-cache'],
@@ -138,7 +143,7 @@ var compiler = {
       project: options['project'],
       skipProject: options['skip-project'],
       skipIgnore: options['skip-ignore'],
-      ignore: options['ignore'] || process.env['TS_NODE_IGNORE'],
+      ignore: ignore,
       ignoreWarnings: options['ignoreWarnings'] || options['ignoreDiagnostics'],
       ignoreDiagnostics: options['ignoreDiagnostics'],
       disableWarnings: options['disableWarnings'],


### PR DESCRIPTION
Hello,

When running `ts-node-dev` with `--ignore '/node_modules/(?!lodash-es/.*)'`, I got this error:

```
[1] TypeError: (options.ignore || ["/node_modules/"]).map is not a function
[1]     at register (/Users/tomesterez/projects/pbv4/node_modules/ts-node/dist/index.js:140:83)
[1]     at Object.init (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/lib/compiler.js:106:7)
[1]     at module.exports (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/lib/index.js:9:12)
[1]     at Object.<anonymous> (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/bin/ts-node-dev:60:1)
[1]     at Module._compile (module.js:653:30)
[1]     at Object.Module._extensions..js (module.js:664:10)
[1]     at Module.load (module.js:566:32)
[1]     at tryModuleLoad (module.js:506:12)
[1]     at Function.Module._load (module.js:498:3)
[1]     at Function.Module.runMain (module.js:694:10)
```

Looks like ts-node is expecting ignore to be an array. See: https://github.com/TypeStrong/ts-node/pull/812