### PR TITLE
Add missing `source-map-support` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "node-notifier": "^5.4.0",
     "resolve": "^1.0.0",
     "rimraf": "^2.6.1",
+    "source-map-support": "^0.5.12",
     "tree-kill": "^1.2.1",
     "ts-node": "*",
     "tsconfig": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,6 +1996,14 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+source-map-support@^0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"


### PR DESCRIPTION
In feb1fb0, a transient dependency was used.

This broke the package, for example when installed with `pnpm`.