### PR TITLE
Add a --watch parameter

### DIFF
--- a/bin/ts-node-dev
+++ b/bin/ts-node-dev
@@ -46,6 +46,7 @@ var opts = minimist(devArgs, {
     'compiler-options',
     'compile-timeout',
     'ignore-watch',
+    'watch',
     'interval',
     'debounce'
   ],

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,9 @@ module.exports = function(script, scriptArgs, nodeArgs, opts) {
     interval: parseInt(opts.interval),
     debounce: parseInt(opts.debounce)
   })
+  for (let watched of (opts.watch || '').split(',')) {
+    watcher.add(watched)
+  }
   var starting = false
   watcher.on('change', function(file) {
     if (file === compiler.tsConfigPath) {
@@ -50,8 +53,8 @@ module.exports = function(script, scriptArgs, nodeArgs, opts) {
     }
     /* eslint-disable no-octal-escape */
     if (cfg.clear) process.stdout.write('\033[2J\033[H')
-    notify('Restarting', file + ' has been modified')    
-    compiler.compileChanged(file)    
+    notify('Restarting', file + ' has been modified')
+    compiler.compileChanged(file)
     if (starting) {
       log.debug('Already starting')
       return


### PR DESCRIPTION
hey -- thanks for such a great project.

we have a script that may need to restart to pick up files it hasn't imported yet, so i added a `--watch` CLI switch. i did a smoke test and it worked, but let me know if there's a better way to do this.