### PR TITLE
Feat/automatic detach from debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ tsnd --respawn server.ts
 - `--prefer-ts` (default: false) - for each `.js` file (that is not in `node_modules`) will try to check if corresponding `.ts` version exists and require it.
 - `--ignore-watch` (default: []) - files/folders to be [ignored by `node-dev`](https://github.com/fgnass/node-dev#ignore-paths). **But also this behaviour enhanced:** it will also make up `new RegExp` of passed ignore string and check absolute paths of required files for match.
   So, to ignore everything in `node_modules`, just pass `--ignore-watch node_modules`.
-
 - `--debug` - Some additional debug output.
 - `--interval` - Polling interval (ms)
 - `--debounce` - Debounce file change events (ms, non-polling mode)
 - `--clear` (`--cls`) Will clear screen on restart
 - `--watch` - Explicitly add files or folders to watch and restart on change (list separated by commas)
+- `--dont-exit-child` - Don't exit the child process on changes/SIGTERM
 
 **Caveats and points of notice:**
 

--- a/bin/ts-node-dev
+++ b/bin/ts-node-dev
@@ -33,7 +33,7 @@ var opts = minimist(devArgs, {
     'prefer-ts-exts',
     'tree-kill',
     'clear', 'cls',
-    'exit-child',
+    'dont-exit-child',
     'rs'
   ],
   string: [

--- a/lib/child-require-hook.js
+++ b/lib/child-require-hook.js
@@ -115,8 +115,9 @@ if (readyFile) {
 
 if (exitChild) {
   process.on('SIGTERM', function() {
+    // This is to make sure debuggers (e.g. Chrome) close
     console.log('Child got SIGTERM, exiting.')
-    process.exit()
+    process.kill(process.pid, 'SIGINT')
   })
 }
 

--- a/lib/child-require-hook.js
+++ b/lib/child-require-hook.js
@@ -11,7 +11,7 @@ var preferTs = false
 var ignore = [/node_modules/]
 var readyFile
 var execCheck = false
-var exitChild = false
+var dontExitChild = false
 var sourceMapSupportPath
 
 var checkFileScript = join(__dirname, 'check-file-exists.js')
@@ -114,6 +114,7 @@ if (readyFile) {
 }
 
 if (exitChild) {
+if (!dontExitChild) {
   process.on('SIGTERM', function() {
     // This is to make sure debuggers (e.g. Chrome) close
     console.log('Child got SIGTERM, exiting.')

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -75,7 +75,8 @@ var compiler = {
       fileData = fileData.replace('execCheck = false', 'execCheck = true')
     }    
     if (options['exit-child']) {
-      fileData = fileData.replace('exitChick = false', 'exitChild = true')
+    if (options['dont-exit-child']) {
+      fileData = fileData.replace('dontExitChild = false', 'dontExitChild = true')
     }
     if (options['ignore'] !== undefined) {
       var ignore = options['ignore']


### PR DESCRIPTION
Branched off from https://github.com/whitecolor/ts-node-dev/pull/93

Specifically I had to revert/alter the undocumented newly added exitChild option. It was wrongly spelled in options, not documented, and simply went contrary to expect behavior. It least IMO. Please enlighten me @whitecolor 