### PR TITLE
disable logging of new line listener

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ module.exports = function(script, scriptArgs, nodeArgs, opts) {
       terminal: false
     })
     rl.on('line', function(line) {
-      console.log('rl.on line', line)
+      // console.log('rl.on line', line)
       if (line.trim() === 'rs') {
         restart('', true)
       }


### PR DESCRIPTION
It disables logging of new line listener:

![image](https://user-images.githubusercontent.com/1016523/68123418-4dc35d80-ff26-11e9-8ff8-39902e61c701.png)

Reproduction steps:

1. run `ts-node-dev`
2. press \<Enter\> button
