### PR TITLE
Allow use of ts-node-dev in pnp yarn berry

### DIFF
--- a/lib/child-require-hook.js
+++ b/lib/child-require-hook.js
@@ -3,6 +3,7 @@ var getCompiledPath = require('./get-compiled-path')
 var sep = require('path').sep
 var join = require('path').join
 var execSync = require('child_process').execSync
+var Module = require("module")
 var compilationId
 var timeThreshold = 0
 var allowJs = false
@@ -97,7 +98,9 @@ function registerJsExtension() {
   }
 }
 
-require(sourceMapSupportPath).install({
+var sourceMapRequire = Module.createRequire ? Module.createRequire(sourceMapSupportPath) : require
+
+sourceMapRequire(sourceMapSupportPath).install({
   hookRequire: true
 })
 

--- a/lib/resolveMain.js
+++ b/lib/resolveMain.js
@@ -1,18 +1,31 @@
-var resolve = require('resolve').sync;
+var resolve = require('resolve');
+
+function resolveRequest(req) {
+  // The `resolve` package is prebuilt through ncc, which prevents
+  // PnP from being able to inject itself into it. To circumvent
+  // this, we simply use PnP directly when available.
+  // @ts-ignore
+  if (process.versions.pnp) {
+    const { resolveRequest } = require(`pnpapi`)
+    return resolveRequest(req, process.cwd() +"/")
+  } else {
+    
+    var opts = {
+      basedir: process.cwd(),
+      paths: [process.cwd()]
+    };
+    return resolve.sync(req, opts)
+  }
+}
 
 module.exports = function (main) {
-  var resolved
-  var opts = {
-    basedir: process.cwd(),
-    paths: [process.cwd()]
-  }
   try {
-    return resolve(main + '.ts', opts);
+    return resolveRequest(main + '.ts');
   } catch (e) {
     try {
-      return resolve(main + '/index.ts', opts);
+      return resolveRequest(main + '/index.ts');
     } catch (e) {
-      return resolve(main, opts);
+      return resolveRequest(main);
     }  
   }  
 };


### PR DESCRIPTION
With yarn 2 (aka berry) pnp is now default.

This change allows ts-node-dev to work in yarn 2, and is backwards compatible with npm and yarn 1