### PR TITLE
Update mkdirp dependency to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dynamic-dedupe": "^0.3.0",
     "filewatcher": "~3.0.0",
     "minimist": "^1.1.3",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "node-notifier": "^5.4.0",
     "resolve": "^1.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Closes #134. `mkdirp` version 0.x is deprecated, this updates mkdirp to the latest 1.x version.