### PR TITLE
Bump minimist for security update

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dateformat": "~1.0.4-1.2.3",
     "dynamic-dedupe": "^0.3.0",
     "filewatcher": "~3.0.0",
-    "minimist": "^1.1.3",
+    "minimist": "^1.2.5",
     "mkdirp": "^0.5.1",
     "node-notifier": "^5.4.0",
     "resolve": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,11 @@ minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"


### PR DESCRIPTION
A recent minimist [security advisory](https://snyk.io/blog/prototype-pollution-minimist/) has caused the GitHub security bot ("dependabot") to flag a repo of mine that uses `ts-node-dev`.
I already patched it for myself via `resolutions` but thought it'd be nice to update upstream for other folks.

NB: I have only tested this on my project, but it was a drop in upgrade/appears to be backwards compatible.