### PR TITLE
fix: add missing peerDependency typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "ts-node": "*",
     "tsconfig": "^7.0.0"
   },
+  "peerDependencies": {
+    "typescript": "*"
+  },
   "devDependencies": {
     "@types/node": "^8.0.4",
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`ts-node-dev` is using `typescript` without declaring it as a dependency https://github.com/whitecolor/ts-node-dev/blob/c0df64c43455d2f8ef144eb9defcd05b6fc52486/lib/index.js#L8


**How did you fix it?**

Declare `typescript` as a peer dependency