### PR TITLE
fix: handle paths with dollar signs and add typescript as a peer dependency

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,7 +12,7 @@ var tsHandler
 var getCompiledPath = require('./get-compiled-path')
 var tmpDir = '.ts-node'
 
-var sourceMapSupportPath = require.resolve('source-map-support').replace(/\\/g, '/')
+var sourceMapSupportPath = require.resolve('source-map-support').replace(/\\/g, '/').replace(/\$/g, '$$$$')
 
 var extensions = ['.ts', '.tsx']
 var empty = function() {}
@@ -103,7 +103,7 @@ var compiler = {
     )
     fileData = fileData.replace(
       './get-compiled-path',
-      path.join(__dirname, 'get-compiled-path').replace(/\\/g, '/')
+      path.join(__dirname, 'get-compiled-path').replace(/\\/g, '/').replace(/\$/g, '$$$$')
     )
     fileData = fileData.replace(
       'var readyFile',
@@ -115,7 +115,7 @@ var compiler = {
     )    
     fileData = fileData.replace(
       /__dirname/,
-      '"' + __dirname.replace(/\\/g, '/') + '"'
+      '"' + __dirname.replace(/\\/g, '/').replace(/\$/g, '$$$$') + '"'
     )
     fs.writeFileSync(compiler.getChildHookPath(), fileData)
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "ts-node": "*",
     "tsconfig": "^7.0.0"
   },
+  "peerDependencies": {
+    "typescript": "*"
+  },
   "devDependencies": {
     "@types/node": "^8.0.4",
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`ts-node-dev` is trying to access `typescript` without declaring it as a dependency and when injecting paths into the `child-require-hook` script it doesn't escape paths with dollar signs in them correctly.

This fixes support for Yarn PnP.

**How did you fix it?**

- Declare `typescript` as a peer dependency
- Escape `$` correctly when injecting a filepath into `child-require-hook.js`