### PR TITLE
Fix broken fs.watch on Linux with Node 14 (issue #143)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,11 @@ module.exports = function(script, scriptArgs, nodeArgs, opts) {
     forcePolling: opts.poll,
     interval: parseInt(opts.interval),
     debounce: parseInt(opts.debounce),
-    recursive: true
+    // [FIXME] On Node 14+, enabling recursion in fs.watch on Linux raises an error
+    recursive: !(
+      process.platform === "linux"
+        && parseInt(process.versions.node.split('.')[0]) >= 14
+    )
   })
   var starting = false
   watcher.on('change', restart)


### PR DESCRIPTION
Fix fatal error being raised by Node 14 when running `fs.watch` with the recursive flag on Linux (issue #143).

According to the [official Node documentation about `fs.watch` caveats](https://nodejs.org/docs/latest/api/fs.html#fs_caveats), the recursive option for `fs.watch` is only supported for _macOS_ and _Windows_. If the OS is unsupported, an `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` will be thrown. Before Node 14, it was simply failing silently, thus "working" until Node 13.

So this fix simply disable the `recursive` flag for Linux and Node 14 combo (that was not working anyway), so the exception is not raised, working the same way as before Node 14.