### PR TITLE
fix ts-node requires from main process

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,7 +15,24 @@ var tmpDir = '.ts-node'
 var sourceMapSupportPath = require.resolve('source-map-support').replace(/\\/g, '/')
 
 var extensions = ['.ts', '.tsx']
-var empty = function() {}
+var jsHandlerReplacement = function(m, fileName) {
+  var code = m._tsNodeDev.code
+  var startTime = m._tsNodeDev.startTime
+  var writeCompiled = m._tsNodeDev.writeCompiled
+
+  try {
+    m._compile(code, fileName)
+    compiler.log.debug(
+      fileName,
+      'compiled in',
+      new Date().getTime() - startTime,
+      'ms'
+    )
+  } catch (e) {
+    code = 'throw ' + 'new Error(' + JSON.stringify(e.message) + ')' + ';'
+    writeCompiled(code)
+  }
+}
 var cwd = process.cwd()
 var compilationInstanceStamp = Math.random()
   .toString()
@@ -126,8 +143,10 @@ var compiler = {
       resolveSync(cwd, typeof project === 'string' ? project : undefined) || ''
 
     var originalJsHandler = require.extensions['.js']
-    require.extensions['.ts'] = empty
-    require.extensions['.tsx'] = empty
+    // ts-node's extension handler calls these and expects them to call
+    // `module._compile` (like what Node's default JS handler does)
+    require.extensions['.ts'] = jsHandlerReplacement
+    require.extensions['.tsx'] = jsHandlerReplacement
     tmpDir = options['cache-directory']
       ? path.resolve(options['cache-directory'])
       : fs.mkdtempSync(path.join(os.tmpdir(), '.ts-node'))
@@ -220,23 +239,16 @@ var compiler = {
     if (fs.existsSync(compiledPath)) {
       return
     }
-    var starTime = new Date().getTime()
+    var startTime = new Date().getTime()
     var m = {
-      _compile: writeCompiled
+      _compile: writeCompiled,
+      _tsNodeDev: {
+        startTime: startTime,
+        code: code,
+        writeCompiled: writeCompiled
+      }
     }
     tsHandler(m, fileName)
-    try {
-      m._compile(code, fileName)
-      compiler.log.debug(
-        fileName,
-        'compiled in',
-        new Date().getTime() - starTime,
-        'ms'
-      )
-    } catch (e) {
-      code = 'throw ' + 'new Error(' + JSON.stringify(e.message) + ')' + ';'
-      writeCompiled(code)
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #150 

### Explanation

ts-node handles compilation by adding a `.ts` require extension which replaces `module._compile` with a Typescript compile function then calls the previous `.ts` extension handler (or defaulting to the `.js` handler). Node's default `.js` extension handler calls `module._compile` which triggers Typescript compilation.

ts-node-dev alters the Node `require` behaviour a little to add debug logs and make the compiled script throw on compilation error. It does this by changing the previous `.ts` extension to an empty function (to bypass ts-node's call to Node's handler) and calls `module._compile` itself after calling ts-node's `.ts` handler.

This works for most cases, however there's an edge case which it fails. If the main process makes a `require()` call to a `.ts` file it will return an empty module because the old `.ts` handler is an empty function so ts-node's `.ts` handler's `module._compile` is never called. This case where a `require()` call is made to a `.ts` file from the main process occurs when using the ttypescript compiler with a transformer that is a Typescript file. When a file is `require`d from an app, ts-node-dev's logic causes the file to be loaded like normal but then ttypescript tries to `require` the transformers and because ts-node-dev does not call `module._compile` they do not get compiled.

The fix is to replace the empty previous extension handler with one which mimics the behaviour of Node's default handler (ie. it calls `module._compile`).