### PR TITLE
Throw error message when polling with no interval

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,10 @@ module.exports = function(script, scriptArgs, nodeArgs, opts) {
     throw new TypeError('`nodeArgs` must be an array')
   }
 
+  if (opts.poll && !opts.interval) {
+    throw new TypeError('`interval` arg must be defined when polling');
+  }
+
   // The child_process
   var child
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -58,3 +58,11 @@ test('It should restart on file change', (t) => {
     }
   })
 })
+
+test('it should throw a helpful error message when using poll without interval', (t) => {
+  spawnTsNodeDev('--poll simple.ts', (error) => {
+    t.match(error, /TypeError: `interval` arg must be defined when polling/, 'Did not throw helpful error message');
+    t.ok(true);
+    t.end();
+  });
+});


### PR DESCRIPTION
**What problem does this PR solve?**

When using the `--poll` argument without an interval, this error would
come from chokidar which was hard to debug initially since I'm not using that package _directly_. 

```
(node:38) UnhandledPromiseRejectionWarning: RangeError [ERR_OUT_OF_RANGE]: The value of "interval" is out of range. It must be an integer. Received NaN
    at StatWatcher.<computed> (internal/fs/watchers.js:90:3)
    at Object.watchFile (fs.js:1489:39)
    at setFsWatchFileListener (/app/node_modules/chokidar/lib/nodefs-handler.js:264:19)
    at NodeFsHandler._watchWithNodeFs (/app/node_modules/chokidar/lib/nodefs-handler.js:325:14)
    at NodeFsHandler._handleFile (/app/node_modules/chokidar/lib/nodefs-handler.js:360:23)
    at NodeFsHandler._addToNodeFs (/app/node_modules/chokidar/lib/nodefs-handler.js:620:21)
    at /app/node_modules/chokidar/index.js:435:21
    at async Promise.all (index 0)
(node:38) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 415)
```

**Solution**:
Throw a helpful error message when this happens so the user knows what to do to fix it.

We could also update the code to just default to `100ms` if no interval is provided since that's the default `chokidar` uses.