### PR TITLE
Docs: update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tsnd --respawn server.ts
 
 **Caveats and points of notice:**
 
-- Especially for large code bases always consider running with `--transpileOnly` flag which is normal for dev workflow and will speed up things greatly. Note, that `ts-node-dev` will not put watch handlers on TS files that contain only types/interfaces (used only for type checking) - this is current limitation by design.
+- Especially for large code bases always consider running with `--transpile-only` flag which is normal for dev workflow and will speed up things greatly. Note, that `ts-node-dev` will not put watch handlers on TS files that contain only types/interfaces (used only for type checking) - this is current limitation by design.
 
 - `--ignore-watch` will NOT affect files ignored by TS compilation. Use `--ignore` option (or `TS_NODE_IGNORE` env variable) to pass **RegExp strings** for filtering files that should not be compiled, by default `/node_modules/` are ignored.
 


### PR DESCRIPTION
Switch the flag in readme to the new one.

I updated to the latest version and realized the flag has changed.