### PR TITLE
Move node-notifier to peerDependencies & check if it is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Look up flags and options can be used [in ts-node's docs](https://github.com/Typ
 - `--watch` - Explicitly add arbitrary files or folders to watch and restart on change (list separated by commas, [chokidar](https://github.com/paulmillr/chokidar) patterns)
 - `--exit-child` - Adds 'SIGTERM' exit handler in a child process.
 - `--rs` - Allow to restart with "rs" line entered in stdio, disabled by default.
+- `--no-notify` - Do not display desktop-notifications (Notifications are only displayed if `node-notifier` is installed).
 
 **Caveats and points of notice:**
 

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,5 +1,10 @@
 var path = require('path');
-var notifier = require('node-notifier');
+var notifier = null;
+try {
+  notifier = require('node-notifier');
+} catch (error) {
+  notifier = null;
+}
 
 function icon(level) {
   return path.resolve(__dirname, '../icons/node_' + level + '.png');
@@ -12,7 +17,7 @@ module.exports = function (cfg, log) {
   return function (title, msg, level) {
     level = level || 'info';
     log([title, msg].filter(_ => _).join(': '), level);
-    if (cfg.notify) {
+    if (notifier !== null && cfg.notify) {
       notifier.notify({
         title: title || 'node.js',
         icon: icon(level),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test-docker": "docker-compose up",
     "ci": "yarn test",
     "ci-local": "docker run --name travis-debug -dit quay.io/travisci/ci-nodejs",
-    "manual": "node ./bin/ts-node-dev --rt 5 --exit-child --tree-kill --clear -r tsconfig-paths/register -r ./test/manual/add-require -r ./test/manual/add-require-2 -r esm -O \"{\\\"module\\\": \\\"es6\\\"}\" --preserve-symlinks --respawn --ignore-watch 'lib' --ignore-watch bin --prefer-ts --debug --poll --interval 1000 --cache-directory .ts-node --inspect -- test/manual/test-script test-arg --fd"
+    "manual": "node ./bin/ts-node-dev --rt 5 --exit-child --tree-kill --clear -r tsconfig-paths/register -r ./test/manual/add-require -r ./test/manual/add-require-2 -r esm -O \"{\\\"module\\\": \\\"es6\\\"}\" --preserve-symlinks --respawn --ignore-watch 'lib' --ignore-watch bin --prefer-ts --debug --poll --interval 1000 --cache-directory .ts-node --inspect -- test/manual/test-script test-arg --fd",
+    "postinstall": "echo If you want desktop-notifications you can run \"npm i node-notifier@^5.4.0\"!"
   },
   "dependencies": {
     "chokidar": "^3.4.0",
@@ -52,7 +53,6 @@
     "dynamic-dedupe": "^0.3.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
-    "node-notifier": "^5.4.0",
     "resolve": "^1.0.0",
     "rimraf": "^2.6.1",
     "source-map-support": "^0.5.12",
@@ -81,6 +81,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
+    "node-notifier": "^5.4.0",
     "typescript": "*"
   }
 }


### PR DESCRIPTION
# Reason for PR
First thanks for this amazing package! It makes development in TS much smoother.

It is really annoying to have `node-notifier` install the binary by default (especially on Windows, as it puts it in the start menu directory). And at least I always use `--no-notify` when using `ts-node-dev`.

I added a `postInstall` script which prints `If you want desktop-notifications you can run "npm i node-notifier@^5.4.0"!`  
I can remove it if you do not want that message after the user has installed this package.

> BTW: It looks like `node-notifier` can safely be updated to the latest version (`7.0.2`)

## Changes
- [faf754dc0b57bd140470394d372e18127139d1b7] - Move node-notifier to peerDependencies & only use it if it is installed & update README.md

## Issues this should fix
- #161 
- #166 