### PR TITLE
Add --script-mode / -s and fix --dir as well as add tests

### DIFF
--- a/bin/ts-node-dev
+++ b/bin/ts-node-dev
@@ -22,7 +22,6 @@ var opts = minimist(devArgs, {
     'exit-child',
     'error-recompile',
     // ts-node
-    'dir',
     'scope',
     'emit',
     'files',
@@ -40,6 +39,7 @@ var opts = minimist(devArgs, {
     'rs'
   ],
   string: [
+    'dir',
     'compile-timeout',
     'ignore-watch',
     'interval',
@@ -60,6 +60,7 @@ var opts = minimist(devArgs, {
     'compiler-options': 'O',
     compiler: 'C',
     project: 'P',
+    'script-mode': 's'
   },
   default: { deps: false, notify: true, rs: false, 'type-check': true },
   unknown: function (arg) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -23,6 +23,48 @@ var originalJsHandler = require.extensions['.js']
 
 var extHandlers = {}
 
+function hasOwnProperty (object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property)
+}
+
+function getCwd(dir, scriptMode, scriptPath) {
+  if (scriptMode) {
+    if (!scriptPath) {
+      throw new TypeError('Script mode must be used with a script name, e.g. `ts-node-dev -s <script.ts>`')
+    }
+
+    if (dir) {
+      throw new TypeError('Script mode cannot be combined with `--dir`')
+    }
+    
+    // Use node's own resolution behavior to ensure we follow symlinks.
+    // scriptPath may omit file extension or point to a directory with or without package.json.
+    // This happens before we are registered, so we tell node's resolver to consider ts, tsx, and jsx files.
+    // In extremely rare cases, is is technically possible to resolve the wrong directory,
+    // because we do not yet know preferTsExts, jsx, nor allowJs.
+    // See also, justification why this will not happen in real-world situations:
+    // https://github.com/TypeStrong/ts-node/pull/1009#issuecomment-613017081
+    const exts = ['.js', '.jsx', '.ts', '.tsx']
+    const extsTemporarilyInstalled = []
+    for (const ext of exts) {
+      if (!hasOwnProperty(require.extensions, ext)) { // tslint:disable-line
+        extsTemporarilyInstalled.push(ext)
+        require.extensions[ext] = function() {} // tslint:disable-line
+      }
+    }
+    try {
+      return path.dirname(require.resolve(scriptPath))
+    } finally {
+      for (const ext of extsTemporarilyInstalled) {
+        delete require.extensions[ext] // tslint:disable-line
+      }
+    }
+  }
+  
+  return dir
+}
+
+
 var compiler = {
   allowJs: false,
   tsConfigPath: '',
@@ -196,12 +238,14 @@ var compiler = {
       ignore = [ignore]
     }
 
+    const scriptPath = options._.length ? path.resolve(cwd, options._[0]) : undefined
+
     var DEFAULTS = tsNode.DEFAULTS
 
     try {
       compiler.service = tsNode.register({
-        // should add --script-mode
-        dir: options['dir'] || DEFAULTS.dir,
+        // --dir does not work (it gives a boolean only) so we only check for script-mode
+        dir: getCwd(options['dir'], options['script-mode'], scriptPath),
         scope: options['dir'] || DEFAULTS.scope,
         emit: options['emit'] || DEFAULTS.emit,
         files: options['files'] || DEFAULTS.files,

--- a/test/fixture/dir-test/imported.js
+++ b/test/fixture/dir-test/imported.js
@@ -1,0 +1,2 @@
+module.exports.hello = 'world'
+;

--- a/test/fixture/dir-test/index.ts
+++ b/test/fixture/dir-test/index.ts
@@ -1,0 +1,4 @@
+
+import values from './imported'
+
+console.log(values)

--- a/test/fixture/dir-test/tsconfig.json
+++ b/test/fixture/dir-test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./*.ts", "./*.js"],
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -155,6 +155,58 @@ test('It handles resolveJsonModule option and loads JSON modules', async (t) => 
   await ps.exit()
 })
 
+test('It should not allow --script-mode and --dir together', async (t) => {
+  const ps = spawnTsNodeDev(
+    [
+      `--script-mode`,
+      `--dir folder`,
+      `simple.ts`,
+    ].join(' ')
+  )//.turnOnOutput()
+  await ps.waitForLine(/TypeError: Script mode cannot be combined with `--dir`/)
+  t.pass('ok')
+  await ps.exit()
+})
+
+test('It should use the tsconfig at --dir when defined', async (t) => {
+  const ps = spawnTsNodeDev(
+    [
+      `--dir dir-test`,
+      `dir-test/index.ts`,
+    ].join(' ')
+  )//.turnOnOutput()
+  await ps.waitForLine(/\{ hello: 'world' \}/)
+  t.pass('ok')
+  await ps.exit()
+})
+
+test('It should use the tsconfig at --script-mode when defined', async (t) => {
+  const ps = spawnTsNodeDev(
+    [
+      `-s`,
+      `dir-test/index.ts`,
+    ].join(' ')
+  )//.turnOnOutput()
+  await ps.waitForLine(/\{ hello: 'world' \}/)
+  t.pass('ok')
+  await ps.exit()
+})
+
+test('It should fail if not using --dir or --script-mode on dir-test/index.ts', async (t) => {
+  const cOptions = { allowJs: true }
+  const ps = spawnTsNodeDev(
+    [
+      `--compiler-options=${JSON.stringify(cOptions)}`,
+      `dir-test/index.ts`,
+    ].join(' ')
+  ).turnOnOutput()
+  await ps.waitForLine(/has no default export./)
+  t.pass('ok')
+  await ps.exit()
+})
+
+
+
 test('It allows to use TS Transformers', async (t) => {
   const cOptions = { plugins: [{ transform: 'ts-nameof', type: 'raw' }] }
   const ps = spawnTsNodeDev(


### PR DESCRIPTION
`ts-node` team is discussing making `--script-mode` a default setting in the near future.  Also, since the `--dir` option was configured incorrectly, `ts-node-dev` had some cases that were impossible to make work properly.  This PR adds the following:

* support for `--script-mode` and `-s` [from `ts-node` ](https://github.com/TypeStrong/ts-node#shebang)
    * uses the same logic used by `ts-node` to handle the arguments here
* support for `--dir` which currently is seutp as a `boolean` rather than a `string` so it doesn't work properly
* tests for all cases provided including error cases.

> It is easy to install since there is no compilation for this project - `yarn add --dev git://github.com/bradennapier/ts-node-dev.git#feature/script-mode"` should work if you want to use this before it is published.  Hopefully since it is quite critical in many cases it will get merged quickly :-) 