### PR TITLE
Isolate cause of compilation failure issues

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,9 +20,6 @@ var cwd = process.cwd()
 var compilationInstanceStamp = Math.random().toString().slice(2)
 
 var originalJsHandler = require.extensions['.js']
-
-// var extHandlers = {}
-
 function hasOwnProperty (object, property) {
   return Object.prototype.hasOwnProperty.call(object, property)
 }
@@ -200,11 +197,6 @@ var compiler = {
   },
   registerTsNode: function () {
     var options = compiler.options
-    // revert back original handler extensions
-    // in case of re-registration after an error
-    extensions.forEach(function (ext) {
-      require.extensions[ext] = originalJsHandler
-    })
 
     var compilerOptionsArg =
       options['compilerOptions'] || options['compiler-options']

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,6 +20,9 @@ var cwd = process.cwd()
 var compilationInstanceStamp = Math.random().toString().slice(2)
 
 var originalJsHandler = require.extensions['.js']
+var originalTsHandler = require.extensions['.ts']
+var originalTsxHandler = require.extensions['.tsx']
+
 function hasOwnProperty (object, property) {
   return Object.prototype.hasOwnProperty.call(object, property)
 }
@@ -198,9 +201,8 @@ var compiler = {
     // revert back original handler extensions
     // in case of re-registration after an error
     require.extensions['.js'] = originalJsHandler
-    extensions.forEach(function (ext) {
-      require.extensions[ext] = empty
-    })
+    require.extensions['.ts'] = originalTsHandler
+    require.extensions['.tsx'] = originalTsxHandler
 
     var compilerOptionsArg =
       options['compilerOptions'] || options['compiler-options']

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -171,9 +171,6 @@ var compiler = {
     compiler.tsConfigPath =
       resolveSync(cwd, typeof project === 'string' ? project : undefined) || ''
 
-    //var originalJsHandler = require.extensions['.js']
-    require.extensions['.ts'] = empty
-    require.extensions['.tsx'] = empty
     tmpDir = options['cache-directory']
       ? path.resolve(options['cache-directory'])
       : fs.mkdtempSync(path.join(os.tmpdir(), '.ts-node'))
@@ -197,6 +194,13 @@ var compiler = {
   },
   registerTsNode: function () {
     var options = compiler.options
+
+    // revert back original handler extensions
+    // in case of re-registration after an error
+    require.extensions['.js'] = originalJsHandler
+    extensions.forEach(function (ext) {
+      require.extensions[ext] = empty
+    })
 
     var compilerOptionsArg =
       options['compilerOptions'] || options['compiler-options']


### PR DESCRIPTION
It appears that after registering `ts-node`, the code then overwrites the methods assigned to `require.extensions['.ts']` and `require.extensions['.tsx']` with the original method designed for use with javascript.

This PR lets the newly registered methods stand.