### PR TITLE
Add cache-directory to string flags

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -92,6 +92,7 @@ const devFlags = {
     'interval',
     'debounce',
     'watch',
+    'cache-directory',
   ],
 }
 
@@ -132,7 +133,7 @@ const opts = minimist(devArgs, {
   alias: {
     ...tsNodeAlias,
     'prefer-ts-exts': 'prefer-ts',
-  },    
+  },
   default: {
     fork: true
   },


### PR DESCRIPTION
This fixes an issue where it is currently impossible to specify cache-directory, because it gets passed to the child node process. It fails like so:

```
$ ts-node-dev --cache-directory=/foo ./src/server
Using ts-node version 8.10.2, typescript version 3.9.7
/usr/local/bin/node: bad option: --cache-directory=/foo
```